### PR TITLE
Spawn multiple workers in a single process

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,7 +1,8 @@
 (function() {
 
 var fs   = require('fs'),
-	yaml = require('js-yaml');
+	  yaml = require('js-yaml'),
+	  _    = require('underscore');
 
 var FiveBeansWorker = require('./worker').FiveBeansWorker;
 
@@ -58,7 +59,7 @@ function readConfiguration(fname)
 
 FiveBeansRunner.prototype.createWorker = function()
 {
-	var config = readConfiguration(this.configpath);
+	var config = _.extend({}, readConfiguration(this.configpath));
 	var options = {
 		id: this.id,
 		host: config.beanstalkd.host,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies"    : {
                         "js-yaml": "0.3.x",
 						            "optimist": "0.3.x",
-                        "winston": "0.5.x"
+                        "winston": "0.5.x",
+                        "underscore": "*"
 					            },
   "devDependencies" : { "mocha": "0.9.x", "chai": "0.1.x" },
   "repository"      : { "type": "git",


### PR DESCRIPTION
Previously both workers would use one configuration file, hence first one would delete handlers keys. Copy object to avoid that
