### PR TITLE
Fix possible condition where ResponseHandler doesn't get called

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -248,6 +248,8 @@ function makeBeanstalkCommand(command, expectedResponse, sendsData)
 			args.push(datalen);
 		}
 
+		this.handlers.push([new ResponseHandler(expectedResponse), callback]);
+		
 		this.send.apply(this, args);
 		if (data)
 		{
@@ -255,8 +257,6 @@ function makeBeanstalkCommand(command, expectedResponse, sendsData)
 			this.stream.write(data);
 			this.stream.write('\r\n');
 		}
-
-		this.handlers.push([new ResponseHandler(expectedResponse), callback]);
 	};
 }
 


### PR DESCRIPTION
If the stream responds really fast, the ResponseHandler won't be set to be executed until too late.
