### PR TITLE
Properly handle server replies that are grouped together

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -169,6 +169,8 @@ ResponseHandler.prototype.process = function(data)
 	var eol = findInBuffer(data, CRLF);
 	if (eol > -1)
 	{
+		var sliceStart;
+
 		// Header is everything up to the windows line break;
 		// body is everything after.
 		this.header = data.toString('utf8', 0, eol);
@@ -185,11 +187,19 @@ ResponseHandler.prototype.process = function(data)
 		{
 			this.parseBody(this.RESPONSES_REQUIRING_BODY[response]);
 			if (this.complete)
+			{
+				sliceStart = eol + 2 + data.length + 2;
+				if (sliceStart >= data.length)
+					return new Buffer(0);
 				return data.slice(eol + 2 + data.length + 2);
+			}
 		}
 		else
 		{
 			this.complete = true;
+			sliceStart = eol + 2;
+			if (sliceStart >= data.length)
+				return new Buffer(0);
 			return data.slice(eol + 2);
 		}
 	}


### PR DESCRIPTION
TCP can group them together in one emitted data, so properly loop over the buffer until there are no more replies.

This was causing callbacks to take a varying amount of time to get called. For low traffic beanstalk clients, it could take hours for the callback to finally get called.
