### PR TITLE
Pinned versions for all deps in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
 	],
 	"dependencies"    :
 	{
-		"js-yaml":  "*",
-		"lodash":   "*",
-		"optimist": "*"
+		"js-yaml":  "2.1.3",
+		"lodash":   "2.2.1",
+		"optimist": "0.6.0"
 	},
 	"devDependencies" :
 	{
-		"blanket":    "*",
-		"chai":       "*",
-		"mocha":      "*",
-		"semver":     "*",
-		"travis-cov": "*"
+		"blanket":    "1.1.5",
+		"chai":       "1.8.1",
+		"mocha":      "1.13.0",
+		"semver":     "2.2.1",
+		"travis-cov": "0.2.4"
 	},
 	"repository"      : { "type": "git", "url" : "git://github.com/ceejbot/fivebeans.git" },
 	"bugs"            : "http://github.com/ceejbot/fivebeans/issues",


### PR DESCRIPTION
To me, this is important, because we're making an on-premise solution. I want to be be sure, for a release, everyone is using the same code.

Pinning the dev dependencies may be going too far, but it is safe,
