### PR TITLE
Disable Nagle's algorithm for beanstalkd connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -40,6 +40,7 @@ FiveBeansClient.prototype.connect = function()
 	var self = this, tmp;
 
 	self.stream = net.createConnection(self.port, self.host);
+	self.stream.setNoDelay();
 
 	self.stream.on('data', function(data)
 	{


### PR DESCRIPTION
To test this:

a single worker that reserves a job and deletes it.
without this we get 25 jobs per second.

With this we get 1700 per second.

Inspiration: 
https://github.com/pascalopitz/nodestalker/blob/master/lib/beanstalk_client.js#L188
