### PR TITLE
Issue #24: Handle multiple responses in a single TCP window

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -101,6 +101,11 @@ FiveBeansClient.prototype.tryHandlingResponse = function()
 					callback.call.apply(callback, [null, null].concat(handler.args));
 				else
 					callback.call(null, handler.args[0]);
+				
+				if (typeof handler.remainder !== 'undefined')
+				{
+					this.buffer = handler.remainder;
+				}
 			}
 			else
 			{
@@ -216,8 +221,12 @@ ResponseHandler.prototype.parseBody = function(how)
 {
 	if ((this.body === undefined) || (this.body === null))
 		return;
-
 	var expectedLength = parseInt(this.args[this.args.length - 1], 10);
+	if (this.body.length > (expectedLength + 2)) {
+		// Body contains multiple responses. Split off the remaining bytes.
+		this.remainder = this.body.slice(expectedLength + 2);
+		this.body = this.body.slice(0, expectedLength + 2);
+	}
 	if (this.body.length === (expectedLength + 2))
 	{
 		this.args.pop();

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -424,5 +424,23 @@ describe('FiveBeansClient', function()
 			});
 		});
 	});
+	
+	describe('concurrent commands', function()
+	{
+		it('can be handled', function(done)
+		{
+			var concurrency = 10;
+			var replied = 0;
+			var handleResponse = function(err, response)
+			{
+				if (++replied >= concurrency) {
+					done();
+				}
+			};
+			for (var i = 0; i < 10; ++i) {
+				consumer.stats_tube(tube, handleResponse);
+			}
+		});
+	});
 
 });


### PR DESCRIPTION
Fix to handle multiple responses in ResponseHandler.parseBody

https://github.com/ceejbot/fivebeans/issues/24#issuecomment-59223052