### PR TITLE
FiveBeansRunner accepts object for configuration

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -6,18 +6,23 @@ var
 	FiveBeansWorker = require('./worker')
 	;
 
-var FiveBeansRunner = function(id, configpath)
+var FiveBeansRunner = function(id, config)
 {
 	assert(id);
-	assert(configpath);
+	assert(config);
 
 	this.id = id;
-	if (configpath[0] !== '/')
-		configpath = process.cwd() + '/' + configpath;
-	this.configpath = configpath;
 
-	if (!fs.existsSync(configpath))
-		throw(new Error(configpath + ' does not exist'));
+	if (typeof config === "string") {
+		if (config[0] !== '/')
+			config = process.cwd() + '/' + config;
+		if (!fs.existsSync(config))
+			throw(new Error(config + ' does not exist'));
+	} else {
+		assert.equal(typeof config, "object");
+	}
+
+	this.config = config;
 
 	this.worker = null;
 	return this;
@@ -48,8 +53,7 @@ FiveBeansRunner.prototype.go = function()
 
 FiveBeansRunner.prototype.readConfiguration = function()
 {
-	var fname = this.configpath;
-	var config = yaml.load(fs.readFileSync(fname, 'utf8'));
+	var config = (typeof this.config === "string") ? yaml.load(fs.readFileSync(this.config, 'utf8')) : this.config;
 	var dirprefix = process.cwd() + '/';
 	var h;
 

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -40,6 +40,15 @@ describe('FiveBeansRunner', function()
 			shouldThrow.must.throw(Error);
 		});
 
+		it('throws when config neither a path nor object', function()
+		{
+			function shouldThrow()
+			{
+				var r = new fivebeans.runner('test', 1);
+			}
+			shouldThrow.must.throw(Error);
+		});
+
 		it('creates a runner when given valid options', function()
 		{
 			var r = new fivebeans.runner('test', 'test/fixtures/runner.yml');


### PR DESCRIPTION
My project already uses dotenv, so I modified FiveBeansRunner to accept object for config:

```
var runner = new FiveBeans.runner('defaultID', {
  beanstalkd: {
    host: process.env.BEANSTALKD_HOST,
    port: process.env.BEANSTALKD_PORT
  },
  watch: [
    "example-tube",
    "testtube"
  ],
  handlers: [
    "./handlers/mass_message.js"
  ],
  ignoreDefault: true
});
```
