### PR TITLE
consistent callback handling for client.quit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -98,9 +98,11 @@ FiveBeansClient.prototype.tryHandlingResponse = function()
 				// shift it off & reset
 				this.handlers.shift();
 				if (handler.success)
-					callback.call.apply(callback, [null, null].concat(handler.args));
+                    callback && callback.call.apply(callback,
+                        [null, null].concat(handler.args));
 				else
-					callback.call(null, handler.args[0]);
+					callback && callback.call(null,
+                        handler.args[0]);
 
 				if (typeof handler.remainder !== 'undefined')
 				{
@@ -203,7 +205,13 @@ ResponseHandler.prototype.process = function(data)
 			return data.slice(eol + 2);
 		}
 	}
-
+    else {
+        // no response expected (quit)
+        if ('' === this.expectedResponse) {
+            this.success = true;
+            this.complete = true;
+        }
+    }
 	return data;
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -98,11 +98,11 @@ FiveBeansClient.prototype.tryHandlingResponse = function()
 				// shift it off & reset
 				this.handlers.shift();
 				if (handler.success)
-                    callback && callback.call.apply(callback,
-                        [null, null].concat(handler.args));
+					callback && callback.call.apply(callback,
+						[null, null].concat(handler.args));
 				else
 					callback && callback.call(null,
-                        handler.args[0]);
+						handler.args[0]);
 
 				if (typeof handler.remainder !== 'undefined')
 				{
@@ -205,13 +205,13 @@ ResponseHandler.prototype.process = function(data)
 			return data.slice(eol + 2);
 		}
 	}
-    else {
-        // no response expected (quit)
-        if ('' === this.expectedResponse) {
-            this.success = true;
-            this.complete = true;
-        }
-    }
+	else {
+		// no response expected (quit)
+		if ('' === this.expectedResponse) {
+			this.success = true;
+			this.complete = true;
+		}
+	}
 	return data;
 };
 


### PR DESCRIPTION
client.quit() breaks when a callback is supplied.
this patch gracefully handles quit command