### PR TITLE
Fixed payload parsing for beanstalkd

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -153,7 +153,7 @@ FiveBeansWorker.prototype.doNext = function()
 			self.emit('job.reserved', jobID);
 
 			var job = null;
-			try { job = JSON.parse(payload); }
+			try { job = JSON.parse(payload.toString('ascii')); }
 			catch (e) { self.emitWarning({ message: 'parsing job JSON', id: jobID, error: e }); }
 			if (!job || !_.isObject(job))
 				self.buryAndMoveOn(jobID);


### PR DESCRIPTION
Since payload is obtained as a buffer we have to make a string conversion to ascii inoder to make a valid payload object out of it.
