### PR TITLE
Do not limit user to use payload job attribute

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -181,7 +181,7 @@ FiveBeansWorker.prototype.runJob = function(jobID, job)
 	}
 	else
 	{
-		self.callHandler(handler, jobID, job.payload);
+		self.callHandler(handler, jobID, job);
 	}
 };
 

--- a/test/test-worker.js
+++ b/test/test-worker.js
@@ -20,10 +20,10 @@ function TestHandler()
 }
 util.inherits(TestHandler, events.EventEmitter);
 
-TestHandler.prototype.work = function(payload, callback)
+TestHandler.prototype.work = function(job, callback)
 {
-	this.emit('result', this.reverseWords(payload));
-	callback(payload, 0);
+	this.emit('result', this.reverseWords(job.payload));
+	callback(job.payload, 0);
 };
 
 TestHandler.prototype.reverseWords = function(input)


### PR DESCRIPTION
why are we restricting user from using his own custom attribute to define the payload/message
The queue can be used for sending messages/jobs/notification. I feel we should not put any restriction on the attributes of the job payload, make available the entire data/payload which a user puts in the queue