### PR TITLE
Fixed #91: failing to parse jobs with non-ascii characters.

### DIFF
--- a/bin/clear-testtube.js
+++ b/bin/clear-testtube.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+var fivebeans = require('../index');
+var client = new fivebeans.client('127.0.0.1', 11300);
+
+function clearAJob()
+{
+	client.peek_buried(function(err, jobid, payload)
+	{
+		if (err && err === 'NOT_FOUND')
+		{
+			console.log('done');
+			process.exit(0);
+		}
+		else if (jobid)
+		{
+			console.log('nuking ' + jobid, payload.toString());
+			client.destroy(jobid, clearAJob);
+		}
+		else
+			console.log(err);
+	});
+}
+
+client.on('connect', function handleConnect()
+{
+	client.use('testtube', function handleWatch(err, response)
+	{
+		if (err) throw(err);
+		clearAJob();
+	});
+}).on('error', function(err)
+{
+	throw(err);
+});
+
+client.connect();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -152,7 +152,7 @@ FiveBeansWorker.prototype.doNext = function()
 			self.emit('job.reserved', jobID);
 
 			var job = null;
-			try { job = JSON.parse(payload.toString('ascii')); }
+			try { job = JSON.parse(payload.toString()); }
 			catch (e) { self.emitWarning({ message: 'parsing job JSON', id: jobID, error: e }); }
 			if (!job || !_.isObject(job))
 				self.buryAndMoveOn(jobID);


### PR DESCRIPTION
Because, well, it was treating all jobs as ascii. Fixed this as suggested, and added a test that fails without the change.

Cleaned up the worker tests a bunch.