### PR TITLE
fix: cleanup before new connection

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,6 +39,11 @@ FiveBeansClient.prototype.connect = function()
 {
 	var self = this, tmp;
 
+	if (self.stream)
+		self.stream.destroy();
+	self.handlers = [];
+	self.buffer = undefined;
+
 	self.stream = net.createConnection(self.port, self.host);
 
 	self.stream.on('data', function(data)


### PR DESCRIPTION
@ceejbot,

Enables reuse of fivebeans handler.

Since I want to reuse the same fivebeans client object for reconnection, I call `FiveBeansClient.prototype.connect()` more than once.
As a result, a callback for an old socket may exist in `self.handlers` after a new socket is created. In this case, the first command with the new socket will stuck, because its callback will not be called (a callback for the old socket will be called instead).