### PR TITLE
Fixed #149: Obsolete documentation for yaml configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,8 @@ runner.go();
 Here's an example yaml configuration:
 
 ```yaml
-beanstalkd:
-    host: "127.0.0.1"
-    port: 11300
+host: "127.0.0.1"
+port: 11300
 watch:
     - 'circle'
     - 'picadilly'
@@ -413,7 +412,7 @@ handlers:
 ignoreDefault: true
 ```
 
-__beanstalkd__: where to connect  
+__host__, __port__: where to connect  
 __watch__: a list of tubes to watch.  
 __handlers__: a list of handler files to require  
 __ignoreDefault__: true if this worker should ignore the default tube

--- a/test/fixtures/badconfig.yml
+++ b/test/fixtures/badconfig.yml
@@ -1,6 +1,5 @@
-beanstalkd:
-    host: "localhost"
-    port: 11300
+host: "localhost"
+port: 11300
 handlers:
     - "./test/fixtures/emitkeys.js"
     - "./dontexist.js"

--- a/test/fixtures/runner.yml
+++ b/test/fixtures/runner.yml
@@ -1,6 +1,5 @@
-beanstalkd:
-    host: "localhost"
-    port: 11300
+host: "localhost"
+port: 11300
 handlers:
     - "./test/fixtures/emitkeys.js"
     - "./test/fixtures/reverse.js"

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -64,8 +64,7 @@ describe('FiveBeansRunner', function()
 			var config = r.readConfiguration();
 
 			config.must.be.an.object();
-			config.must.have.property('beanstalkd');
-			config.beanstalkd.host.must.equal('localhost');
+			config.host.must.equal('localhost');
 			config.watch.must.be.an.array();
 			config.ignoreDefault.must.equal(true);
 		});


### PR DESCRIPTION
Updated documentation for yaml configuration.
Take a look at https://github.com/ceejbot/fivebeans/issues/149