### PR TITLE
reset handlers for a new connection, fix for issue#133

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -39,6 +39,8 @@ FiveBeansClient.prototype.connect = function()
 {
 	var self = this, tmp;
 
+    self.handlers = [];
+
 	self.stream = net.createConnection(self.port, self.host);
 
 	self.stream.on('data', function(data)


### PR DESCRIPTION
Handlers must be reset e.g. if you re-connect using the same client after connection has been lost. Response processing is otherwise quite chaotic and dependent on previous client handlers state.

This should fix issue#133