### PR TITLE
Resolve build issue with beanstalk.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ node_js:
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq beanstalkd
-    - sudo beanstalkd -d -l 127.0.0.1 -p 11300
+    - sudo beanstalkd -l 127.0.0.1 -p 11300 &
 script: npm run travis
 after_success: npm run coverage


### PR DESCRIPTION
The current travis-ci build is failing to start `beanstalkd`.  This is because the argument `-d` is not recognized by the `beanstalkd` application (perhaps it was in a previous version of beanstalk?).  

I switched to start `beanstalkd` in the background using `&` which likely achieve the same intent