### PR TITLE
Update Readme with real host, port yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,8 @@ runner.go();
 Here's an example yaml configuration:
 
 ```yaml
-beanstalkd:
-    host: "127.0.0.1"
-    port: 11300
+host: "127.0.0.1"
+port: 11300
 watch:
     - 'circle'
     - 'picadilly'

--- a/examples/exampleconfig.yml
+++ b/examples/exampleconfig.yml
@@ -1,6 +1,5 @@
-beanstalkd:
-    host: "localhost"
-    port: 11300
+host: "localhost"
+port: 11300
 handlers:
     - "./handlers/emitkeys.js"
     - "./handlers/reverse.js"


### PR DESCRIPTION
### What this PR does?
- Update Readme.md file
- Update `examples/exampleconfig.yml`

### Any context you can provicde
- `lib/worker.js` is not taking the configuration over beanstalkd key, which causes always setting default host and port [worker:31](https://github.com/ceejbot/fivebeans/blob/master/lib/worker.js#L31)

